### PR TITLE
use versioning for deploysbot

### DIFF
--- a/.github/workflows/reusable-cd.yaml
+++ b/.github/workflows/reusable-cd.yaml
@@ -139,7 +139,7 @@ jobs:
           console.log("this is pr number: " + pr)
           return pr
     - name: "Create jira tickets and link items, send deployment notification"
-      uses: adore-me/github-action-deploysbot@master
+      uses: adore-me/github-action-deploysbot@v0.0.1
       if: "${{ inputs.create-jira-tickets && steps.pr_id.outputs.result > 0}}"
       with:
         JIRA_USER: ${{ secrets.JIRA_USER }}


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
