### PR TITLE
Bump composer action version

### DIFF
--- a/.github/workflows/php-reusable-cd.yaml
+++ b/.github/workflows/php-reusable-cd.yaml
@@ -76,7 +76,7 @@ jobs:
         with:
           tag: ${{ inputs.php-image-tag }}
       - name: 'Composer Install'
-        uses: adore-me/gha-composer@v1.0.1
+        uses: adore-me/gha-composer@v1.0.8
         with:
           php-image: ${{ steps.set-php-image.outputs.image }}
           composer-no-dev: 'true'


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
