### PR TITLE
Added config cache option

### DIFF
--- a/.github/workflows/php-reusable-cd.yaml
+++ b/.github/workflows/php-reusable-cd.yaml
@@ -75,17 +75,25 @@ jobs:
           composer-no-dev: 'true'
           gh-oauth-token: ${{ secrets.GH_OAUTH_TOKEN }}
 
-      - name: 'Get cache option from CI config'
-        id: project-cache-config
+      - name: 'Get route cache option from CI config'
+        id: project-cache-routes
         uses: jbutcher5/read-yaml@main
         with:
           file: './ci/config.yaml'
           key-path: '["prod-cache-routes"]'
 
-      - name: 'Running extra commands'
-        uses: adore-me/gha-run-cmds@v1.1.1
+      - name: 'Get config cache option from CI config'
+        id: project-cache-config
+        uses: jbutcher5/read-yaml@main
         with:
-          run-laravel-route-cache: ${{ steps.project-cache-config.outputs.data }}
+          file: './ci/config.yaml'
+          key-path: '["prod-cache-config"]'
+
+      - name: 'Running extra commands'
+        uses: adore-me/gha-run-cmds@v1.1.2
+        with:
+          run-laravel-route-cache: ${{ steps.project-cache-routes.outputs.data }}
+          run-laravel-config-cache: ${{ steps.project-cache-config.outputs.data }}
 
       - name: 'Docker build & push image'
         uses: docker/build-push-action@v3.2.0


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
