### PR TITLE
Add reusable promote workflow

### DIFF
--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -55,3 +55,6 @@ jobs:
           id: ${{ github.event.release.id }}
           name: "prod-${{ github.event.inputs.version }}"
           replacename: true
+      - name: 'Summarize with Docker image Success'
+        run: |
+          echo 'Version `${{ github.event.inputs.version }}` promoted to PROD as `prod-${{ github.event.inputs.version }}`' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -31,28 +31,30 @@ jobs:
           registry: us.gcr.io
           username: _json_key
           password: ${{ secrets.GCR_CREDENTIALS }} # Use org secrets for this
-      - name: Setup ENV
+      - name: Setup
+        id: setup
         run: |-
-          UAT_IMAGE_TAG=quay.io/adoreme/${{github.repository.name}}:${{ github.event.inputs.version }}
-          QUAY_PROD_IMAGE_TAG=quay.io/adoreme/${{github.repository.name}}:prod-${{ github.event.inputs.version }}
-          GCR_PROD_IMAGE_TAG=us.gcr.io/am-production-268015/${{github.repository.name}}:prod-${{ github.event.inputs.version }}
+          echo promotedTag=prod-${{ github.event.inputs.version }} >> $GITHUB_STATE
+          echo "uatImage=quay.io/adoreme/${{github.repository.name}}:${{ github.event.inputs.version }}" >> $GITHUB_STATE
+          echo "quayProdImage=quay.io/adoreme/${{github.repository.name}}:prod-${{ github.event.inputs.version }}" >> $GITHUB_STATE
+          echo "gcrProdImage=us.gcr.io/am-production-268015/${{github.repository.name}}:prod-${{ github.event.inputs.version }}" >> $GITHUB_STATE
       - name: Pull image from Quay
-        run: docker pull $UAT_IMAGE_TAG
+        run: docker pull ${{ steps.setup.outputs.uatImage }}
       - name: Tag image for Quay and Push
         run: |-
-          docker tag $UAT_IMAGE_TAG $QUAY_PROD_IMAGE_TAG
-          docker push $QUAY_PROD_IMAGE_TAG
+          docker tag ${{ steps.setup.outputs.uatImage }} ${{ steps.setup.outputs.quayProdImage }}
+          docker push ${{ steps.setup.outputs.quayProdImage }}
       - name: Tag image for GCR and Push
         run: |-
-          docker tag $UAT_IMAGE_TAG $GCR_PROD_IMAGE_TAG
-          docker push $GCR_PROD_IMAGE_TAG
+          docker tag ${{ steps.setup.outputs.uatImage }} ${{ steps.setup.outputs.gcrProdImage }}
+          docker push ${{ steps.setup.outputs.gcrProdImage }}
       - name: Update release
         uses: irongut/EditRelease@v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           id: ${{ github.event.release.id }}
-          name: "prod-${{ github.event.inputs.version }}"
+          name: ${{ steps.setup.outputs.promotedTag }}
           replacename: true
       - name: 'Summarize with Docker image Success'
         run: |
-          echo 'Version `${{ github.event.inputs.version }}` promoted to PROD as `prod-${{ github.event.inputs.version }}`' >> $GITHUB_STEP_SUMMARY
+          echo 'Version `${{ github.event.inputs.version }}` promoted to PROD as `${{ steps.setup.outputs.promotedTag }}`' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -50,6 +50,9 @@ jobs:
         run: |-
           docker tag ${{ steps.setup.outputs.uatImage }} ${{ steps.setup.outputs.gcrProdImage }}
           docker push ${{ steps.setup.outputs.gcrProdImage }}
+      - name: 'Summarize with Docker image Success'
+        run: |
+          echo 'Version `${{ github.event.inputs.version }}` promoted to PROD as `${{ steps.setup.outputs.promotedTag }}` by ${{ github.actor }}' >> $GITHUB_STEP_SUMMARY
       - name: Get release
         id: get-release
         uses: cardinalby/git-get-release-action@1.2.4
@@ -64,6 +67,4 @@ jobs:
           id: ${{ steps.get-release.outputs.id }}
           name: ${{ steps.setup.outputs.promotedTag }}
           replacename: true
-      - name: 'Summarize with Docker image Success'
-        run: |
-          echo "Version `${{ github.event.inputs.version }}` promoted to PROD as `${{ steps.setup.outputs.promotedTag }}`" >> $GITHUB_STEP_SUMMARY
+

--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -34,10 +34,10 @@ jobs:
       - name: Setup
         id: setup
         run: |-
-          echo promotedTag=prod-${{ github.event.inputs.version }} >> $GITHUB_STATE
-          echo "uatImage=quay.io/adoreme/${{github.repository.name}}:${{ github.event.inputs.version }}" >> $GITHUB_STATE
-          echo "quayProdImage=quay.io/adoreme/${{github.repository.name}}:prod-${{ github.event.inputs.version }}" >> $GITHUB_STATE
-          echo "gcrProdImage=us.gcr.io/am-production-268015/${{github.repository.name}}:prod-${{ github.event.inputs.version }}" >> $GITHUB_STATE
+          echo "promotedTag=prod-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          echo "uatImage=quay.io/adoreme/${{github.repository.name}}:${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          echo "quayProdImage=quay.io/adoreme/${{github.repository.name}}:prod-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          echo "gcrProdImage=us.gcr.io/am-production-268015/${{github.repository.name}}:prod-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
       - name: Pull image from Quay
         run: docker pull ${{ steps.setup.outputs.uatImage }}
       - name: Tag image for Quay and Push
@@ -57,4 +57,4 @@ jobs:
           replacename: true
       - name: 'Summarize with Docker image Success'
         run: |
-          echo 'Version `${{ github.event.inputs.version }}` promoted to PROD as `${{ steps.setup.outputs.promotedTag }}`' >> $GITHUB_STEP_SUMMARY
+          echo "Version `${{ github.event.inputs.version }}` promoted to PROD as `${{ steps.setup.outputs.promotedTag }}`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -50,11 +50,18 @@ jobs:
         run: |-
           docker tag ${{ steps.setup.outputs.uatImage }} ${{ steps.setup.outputs.gcrProdImage }}
           docker push ${{ steps.setup.outputs.gcrProdImage }}
+      - name: Get release
+        id: get-release
+        uses: cardinalby/git-get-release-action@1.2.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ github.event.inputs.version }}
       - name: Update release
         uses: irongut/EditRelease@v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          id: ${{ github.event.release.id }}
+          id: ${{ steps.get-release.outputs.id }}
           name: ${{ steps.setup.outputs.promotedTag }}
           replacename: true
       - name: 'Summarize with Docker image Success'

--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -37,9 +37,9 @@ jobs:
         id: setup
         run: |-
           echo "promotedTag=prod-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          echo "uatImage=quay.io/adoreme/${{github.repository.name}}:${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          echo "quayProdImage=quay.io/adoreme/${{github.repository.name}}:prod-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          echo "gcrProdImage=us.gcr.io/am-production-268015/${{github.repository.name}}:prod-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          echo "uatImage=quay.io/adoreme/${{ github.event.repository.name }}:${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          echo "quayProdImage=quay.io/adoreme/${{ github.event.repository.name }}:prod-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          echo "gcrProdImage=us.gcr.io/am-production-268015/${{ github.event.repository.name }}:prod-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
       - name: Pull image from Quay
         run: docker pull ${{ steps.setup.outputs.uatImage }}
       - name: Tag image for Quay and Push

--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -52,7 +52,7 @@ jobs:
           docker push ${{ steps.setup.outputs.gcrProdImage }}
       - name: 'Summarize with Docker image Success'
         run: |
-          echo 'Version `${{ github.event.inputs.version }}` promoted to PROD as `${{ steps.setup.outputs.promotedTag }}` by ${{ github.actor }}' >> $GITHUB_STEP_SUMMARY
+          echo 'Version `${{ github.event.inputs.version }}` promoted to PROD as `${{ steps.setup.outputs.promotedTag }}` by @${{ github.actor }}' >> $GITHUB_STEP_SUMMARY
       - name: Get release
         id: get-release
         uses: cardinalby/git-get-release-action@1.2.4

--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -19,6 +19,8 @@ jobs:
     name: Promote to PROD
     runs-on: ubuntu-latest
     steps: 
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Login Docker registry (Quay)
         uses: docker/login-action@v2.1.0
         with:

--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -8,8 +8,6 @@ on:
         type: string
         required: true
     secrets:
-      GH_OAUTH_TOKEN:
-        required: true
       QUAY_USER:
         required: true
       QUAY_PASSWORD:

--- a/.github/workflows/reusable-promote.yaml
+++ b/.github/workflows/reusable-promote.yaml
@@ -1,0 +1,57 @@
+name: Reusable promote to PROD workflow
+
+on: 
+  workflow_call:
+    inputs: 
+      version:
+        description: 'Version to promote (ex: v1.0.3)'
+        type: string
+        required: true
+    secrets:
+      GH_OAUTH_TOKEN:
+        required: true
+      QUAY_USER:
+        required: true
+      QUAY_PASSWORD:
+        required: true
+      GCR_CREDENTIALS:
+        required: true
+jobs:
+  promote:
+    name: Promote to PROD
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Login Docker registry (Quay)
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }} # Use org secrets for this
+          password: ${{ secrets.QUAY_PASSWORD }} # Use org secrets for this
+      - name: Login backup Docker registry (GCR)
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: us.gcr.io
+          username: _json_key
+          password: ${{ secrets.GCR_CREDENTIALS }} # Use org secrets for this
+      - name: Setup ENV
+        run: |-
+          UAT_IMAGE_TAG=quay.io/adoreme/${{github.repository.name}}:${{ github.event.inputs.version }}
+          QUAY_PROD_IMAGE_TAG=quay.io/adoreme/${{github.repository.name}}:prod-${{ github.event.inputs.version }}
+          GCR_PROD_IMAGE_TAG=us.gcr.io/am-production-268015/${{github.repository.name}}:prod-${{ github.event.inputs.version }}
+      - name: Pull image from Quay
+        run: docker pull $UAT_IMAGE_TAG
+      - name: Tag image for Quay and Push
+        run: |-
+          docker tag $UAT_IMAGE_TAG $QUAY_PROD_IMAGE_TAG
+          docker push $QUAY_PROD_IMAGE_TAG
+      - name: Tag image for GCR and Push
+        run: |-
+          docker tag $UAT_IMAGE_TAG $GCR_PROD_IMAGE_TAG
+          docker push $GCR_PROD_IMAGE_TAG
+      - name: Update release
+        uses: irongut/EditRelease@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          id: ${{ github.event.release.id }}
+          name: "prod-${{ github.event.inputs.version }}"
+          replacename: true


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
