### PR TITLE
update deploysbot for jira cloud

### DIFF
--- a/.github/workflows/php-reusable-cd.yaml
+++ b/.github/workflows/php-reusable-cd.yaml
@@ -44,10 +44,7 @@ on:
         required: true
       SLACK_WEBHOOK:
         required: true
-      DEPLOYSBOT_HEADER:
-        required: true
-      DEPLOYSBOT_HEADER_VALUE:
-        required: true
+
 jobs:
   release:
     name: 'Release new version'
@@ -143,7 +140,7 @@ jobs:
             return pr
 
       - name: 'Create jira tickets and link items, send deployment notification'
-        uses: adore-me/github-action-deploysbot@v0.0.2
+        uses: adore-me/github-action-deploysbot@v1.0.0
         if: inputs.create-jira-tickets && steps.pr-id.outputs.result > 0
         with:
           JIRA_USER: ${{ secrets.JIRA_USER }}
@@ -153,5 +150,3 @@ jobs:
           GH_PR_NUMBER: ${{ steps.pr-id.outputs.result }}
           GH_TAG: ${{ needs.release.outputs.tag }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          DEPLOYSBOT_HEADER: ${{ secrets.DEPLOYSBOT_HEADER }}
-          DEPLOYSBOT_HEADER_VALUE: ${{ secrets.DEPLOYSBOT_HEADER_VALUE }}


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
