### PR TITLE
Update reusable-cleanup-build-cache.yaml

### DIFF
--- a/.github/workflows/reusable-cleanup-build-cache.yaml
+++ b/.github/workflows/reusable-cleanup-build-cache.yaml
@@ -14,9 +14,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Deleting cache related to PR
         run: |
-          sudo apt-get -q update
-          sudo apt-get -q install -y jq
-          
           # Get complete cache list
           cache_list=$(curl -L \
           -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
