### PR TITLE
[Add] new secret for GCP_SA_CREDENTIALS

### DIFF
--- a/.github/workflows/js-reusable-cd.yaml
+++ b/.github/workflows/js-reusable-cd.yaml
@@ -31,6 +31,8 @@ on:
         required: true
       NPM_TOKEN:
         required: true
+      GCP_SA_CREDENTIALS:
+        required: false
 jobs:
   release:
     name: 'Release new version'


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
