### PR TITLE
[Add] new secret for GCP_SA_CREDENTIALS  - as build-args

### DIFF
--- a/.github/workflows/js-reusable-cd.yaml
+++ b/.github/workflows/js-reusable-cd.yaml
@@ -115,6 +115,7 @@ jobs:
           build-args: |
             NPM_TOKEN=${{ secrets.NPM_TOKEN }}
             NODE_VERSION=${{ steps.config.outputs.nodeVersion }}
+            GCP_SA_CREDENTIALS=${{ secrets.GCP_SA_CREDENTIALS }}
           labels: |
             app.version=${{ steps.release.outputs.tag_name }}
             git.commit.sha=${{ github.sha }}


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
