### PR TITLE
Fixed workflow error caused by grep status

### DIFF
--- a/.github/workflows/reusable-cleanup-build-cache.yaml
+++ b/.github/workflows/reusable-cleanup-build-cache.yaml
@@ -29,7 +29,7 @@ jobs:
           fi
           
           # Get complete cache list related to PR
-          cache_list_pr=$(echo "$cache_list" | grep -e "-${{github.event.number}}-")
+          cache_list_pr=$(echo "$cache_list" | grep -e "-${{github.event.number}}-"), echo "$?"
           if [[ -n $cache_list_pr ]]; then
             echo -e "Cache list related to pr:\n$cache_list_pr"
             echo ""


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
