### PR TITLE
Update js-reusable-cd.yaml

### DIFF
--- a/.github/workflows/js-reusable-cd.yaml
+++ b/.github/workflows/js-reusable-cd.yaml
@@ -113,6 +113,7 @@ jobs:
           file: ci/Dockerfile
           push: true
           build-args: |
+            APP_VERSION=${{ steps.release.outputs.version }}
             NPM_TOKEN=${{ secrets.NPM_TOKEN }}
             NODE_VERSION=${{ steps.config.outputs.nodeVersion }}
             GCP_SA_CREDENTIALS=${{ secrets.GCP_SA_CREDENTIALS }}


### PR DESCRIPTION
- added APP_VERSION docker ARG

**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
