### PR TITLE
remove condition from dev-deploy-app

### DIFF
--- a/.github/workflows/dev-deploy-app-php.yaml
+++ b/.github/workflows/dev-deploy-app-php.yaml
@@ -24,7 +24,7 @@ on:
 
 concurrency:
   group: ${{ inputs.namespace }}
-run-name: ${{ github.event_name == 'workflow_dispatch' && tojson(inputs) }}
+run-name: ${{ tojson(inputs) }}
 jobs:
   deploy-qa-envs:
     timeout-minutes: 10


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
