### PR TITLE
WEB-2558 - added new phpunit with coverage version

### DIFF
--- a/.github/workflows/php-lib-reusable-tests.yaml
+++ b/.github/workflows/php-lib-reusable-tests.yaml
@@ -132,7 +132,7 @@ jobs:
           gh-oauth-token: ${{ steps.gha-token.outputs.token }}
 
       - name: 'Run PHPUnit'
-        uses: adore-me/gha-phpunit@v3.3.5
+        uses: adore-me/gha-phpunit@v3.3.6
         with:
           enable-mysql: ${{ inputs.enable-mysql }}
           enable-redis: ${{ inputs.enable-redis }}


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
