### PR TITLE
update wf to use merge queue

### DIFF
--- a/.github/workflows/dev-deploy-app-js.yaml
+++ b/.github/workflows/dev-deploy-app-js.yaml
@@ -186,10 +186,23 @@ jobs:
           sed -i "s#TAG\b#$tag#1" "$filePath"
           echo "Replaced tag with $tag in helm-release.yaml"
 
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: github-actions[bot]
-          author_email: 41898282+github-actions[bot]@users.noreply.github.com
-          branch: main
-          message: "Creating release: ${{ inputs.namespace }} - ${{ github.event.repository.name }}"
+      - name: pull-request to kube-dev
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          
+          status=$(git status --porcelain)
+          if [ -z "$status" ]; then
+            # If the status is empty, there is nothing to commit
+            echo "Nothing to commit."
+            exit 0
+          fi
+          
+          branch="deploy-${{ inputs.namespace }}-${{ github.event.repository.name }}-${{ steps.set-tag.outputs.tag }}-$(date +'%Y%m%d%H%M%S')"
+          git checkout -b $branch
+          git commit --all -m "Deploy ${{ github.event.repository.name }} in ${{ inputs.namespace }} with tag ${{ steps.set-tag.outputs.tag }}"
+          git push --set-upstream origin $branch
+          gh pr create --base main \
+            --title "Deploy ${{ github.event.repository.name }} with ${{ steps.set-tag.outputs.tag }} on ${{ inputs.namespace }}" \
+            --body 'PR triggered by [${{ github.event.repository.name }}](https://github.com/adore-me/${{ github.event.repository.name }}/blob/master/.github/workflows/deploy-app-to-dev-ns.yaml)'
+          gh pr merge --rebase

--- a/.github/workflows/dev-deploy-app-php.yaml
+++ b/.github/workflows/dev-deploy-app-php.yaml
@@ -204,10 +204,23 @@ jobs:
             echo "Replaced namespace with $team_namespace in $file"
           done
 
-      - name: Commit to kube-dev
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: github-actions[bot]
-          author_email: 41898282+github-actions[bot]@users.noreply.github.com
-          branch: main
-          message: "Creating release: ${{ inputs.namespace }} - ${{ github.event.repository.name }}"
+      - name: pull-request to kube-dev
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          
+          status=$(git status --porcelain)
+          if [ -z "$status" ]; then
+            # If the status is empty, there is nothing to commit
+            echo "Nothing to commit."
+            exit 0
+          fi
+          
+          branch="deploy-${{ inputs.namespace }}-${{ github.event.repository.name }}-${{ steps.set-tag.outputs.tag }}-$(date +'%Y%m%d%H%M%S')"
+          git checkout -b $branch
+          git commit --all -m "Deploy ${{ github.event.repository.name }} in ${{ inputs.namespace }} with tag ${{ steps.set-tag.outputs.tag }}"
+          git push --set-upstream origin $branch
+          gh pr create --base main \
+            --title "Deploy ${{ github.event.repository.name }} with ${{ steps.set-tag.outputs.tag }} on ${{ inputs.namespace }}" \
+            --body 'PR triggered by [${{ github.event.repository.name }}](https://github.com/adore-me/${{ github.event.repository.name }}/blob/master/.github/workflows/deploy-app-to-dev-ns.yaml)'
+          gh pr merge --rebase


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
